### PR TITLE
fix: activity graph for github light theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,16 @@ _In my non-coding hours, I enjoy sketching, delving into 3D modeling, gaming, or
 
 <br>
 
-<h2 align="center">📈 <i>Stats</i></h2>
+<h2 align='center'><i><a href="https://github.com/Ashutosh00710/github-readme-activity-graph">Stats 📈</i></h2>
+<p align="center">
+<a href="https://github.com/Ashutosh00710/github-readme-activity-graph#gh-light-mode-only">
+ <img src="https://grag.onrender.com/graph?username=Kshitij978&theme=react&area=true&hide_border=true#gh-light-mode-only" width="100%">
+</a>
+<a href="https://github.com/Ashutosh00710/github-readme-activity-graph#gh-dark-mode-only">
+ <img src="https://grag.onrender.com/graph?username=Kshitij978&bg_color=none&theme=react&area=true#gh-dark-mode-only" width="100%">
+</a>
+</p>
 
-[![Kshitij's github activity graph](https://grag.onrender.com/graph?username=Kshitij978&bg_color=none&theme=react&area=true)](https://github.com/Ashutosh00710/github-readme-activity-graph)
 
 <!--<img align="left" src="ks.svg" height="300"></img>-->
 


### PR DESCRIPTION
## Summary
This PR will fix the github readme activity graph's visibility for github light theme.

## Issue
<img width="910" alt="Screenshot 2023-12-31 at 10 50 46 AM" src="https://github.com/Kshitij978/Kshitij978/assets/42907572/b89d0ad6-12df-4ea4-a5c1-44f8187c6065">
Above screenshot shows that the graph is not readable for a user (like me 😉) using github in light mode.

## Fix
Now there are two different graphs will render for 2 different themes
**For light mode**: React theme
<img width="892" alt="Screenshot 2023-12-31 at 11 03 57 AM" src="https://github.com/Kshitij978/Kshitij978/assets/42907572/916324d8-7435-47fa-8dc7-b8fd0e2e2695">

**For dark theme**: React theme with background color none
<img width="896" alt="Screenshot 2023-12-31 at 11 09 39 AM" src="https://github.com/Kshitij978/Kshitij978/assets/42907572/cf8cd93f-42e0-47be-a787-986b286373a7">
